### PR TITLE
Deploy plugin to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,20 @@ This plugin will both create the mapped paper dependency and install it to your 
 
 Although you probably want to use Gradle and [paperweight-userdev](https://github.com/PaperMC/paperweight-test-plugin) instead.
 
-**Note:** This maven plugin is not on any repository, [see below](#no-maven-repository).
-
 ## Usage (IntelliJ)
 1. Add `.paper-nms` to your `.gitignore`.
 
-2. Add the plugin to your `pom.xml`:
+2. Add the plugin and its repository to your `pom.xml`:
 ```xml
+<pluginRepositories>
+    ...
+    <pluginRepository>
+        <id>bytecode.space</id>
+        <url>https://repo.bytecode.space/repository/maven-public/</url>
+    </pluginRepository>
+    ...
+</pluginRepositories>
+
 <build>
     <plugins>
         ...
@@ -38,18 +45,18 @@ Although you probably want to use Gradle and [paperweight-userdev](https://githu
 <dependency>
     <groupId>ca.bkaw</groupId>
     <artifactId>paper-nms</artifactId>
-    <version>1.18.1-SNAPSHOT</version>
+    <version>1.18.2-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
 ```
 
-Change `1.18.1` to the desired version.
+Change `1.18.2` to the desired version.
 
 4. Reload the project.
 
 ![Press the "Load Maven Changes" button](docs/img/step-3.png)
 
-A `Cannot resolve ca.bkaw:paper-nms:1.18.1-SNAPSHOT` message is expected.
+A `Cannot resolve ca.bkaw:paper-nms:1.18.2-SNAPSHOT` message is expected.
 
 5. To create the missing dependency, run `init`.
 ![Instructions for running the paper-nms:init maven goal](docs/img/step-4.png)
@@ -60,9 +67,6 @@ For arrow (4), double-click `paper-nms:init` to run it.
 7. Done! Your project should now have a Mojang mapped paper dependency, and when you build you project (for example with `mvn package`) the artifact will be remapped back to spigot mappings.
 
 ## Issues
-### No maven repository
-This maven plugin is currently not on any repository. Instead, git clone this repository and run `mvn install` to install the plugin to your local repository.
-
 ### Only works for 1.17.x and 1.18.x.
 On some older spigot versions, mappings use a package rename to avoid having to retype `net/minecraft/server` for every class mapping. See [issue #2](https://github.com/Alvinn8/paper-nms-maven-plugin/issues/2).
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,32 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.6.0</version>
             </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>bytecode.space-snapshots</id>
+            <url>https://repo.bytecode.space/repository/maven-snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>bytecode.space-releases</id>
+            <url>https://repo.bytecode.space/repository/maven-releases/</url>
+        </repository>
+    </distributionManagement>
 
     <repositories>
         <repository>


### PR DESCRIPTION
As proposed on discord :)

[The CI](https://ci.bytecode.space/view/All%20Jobs/job/Alvinn8/job/paper-nms-maven-plugin/) will automatically build and deploy the plugin. Keep in mind that the releases repo does **not** allow redeployment (snapshots *can* be redeployed). This means the CI build/deploy will fail if you have two commits with the same non-snapshot version number (and only the first build will be deployed to the repo).