### PR TITLE
Update Paper endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Although you probably want to use Gradle and [paperweight-userdev](https://githu
         <plugin>
             <groupId>ca.bkaw</groupId>
             <artifactId>paper-nms-maven-plugin</artifactId>
-            <version>1.2</version>
+            <version>1.2.1</version>
             <executions>
                 <execution>
                     <phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.bkaw</groupId>
     <artifactId>paper-nms-maven-plugin</artifactId>
-    <version>1.2</version>
+    <version>1.2.1</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -319,7 +319,7 @@ public abstract class MojoBase extends AbstractMojo {
 
         MavenArtifactRepository paperRepo = new MavenArtifactRepository(
             "papermc",
-            "https://papermc.io/repo/repository/maven-public/",
+            "https://repo.papermc.io/repository/maven-public/",
             new DefaultRepositoryLayout(),
             new ArtifactRepositoryPolicy(),
             new ArtifactRepositoryPolicy()
@@ -582,7 +582,7 @@ public abstract class MojoBase extends AbstractMojo {
 
         InputStream inputStream;
         try {
-            inputStream = new URL("https://papermc.io/api/v2/projects/paper/versions/" + gameVersion).openStream();
+            inputStream = new URL("https://api.papermc.io/v2/projects/paper/versions/" + gameVersion).openStream();
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to download paper builds", e);
         }
@@ -599,7 +599,7 @@ public abstract class MojoBase extends AbstractMojo {
         getLog().info("The latest paper build for " + gameVersion + " is " + highestBuild);
 
         getLog().info("Downloading paper");
-        this.downloadFile("https://papermc.io/api/v2/projects/paper/versions/" + gameVersion + "/builds/" + highestBuild + "/downloads/paper-" + gameVersion + "-" + highestBuild + ".jar", paperclipPath);
+        this.downloadFile("https://api.papermc.io/v2/projects/paper/versions/" + gameVersion + "/builds/" + highestBuild + "/downloads/paper-" + gameVersion + "-" + highestBuild + ".jar", paperclipPath);
     }
 
     /**
@@ -856,7 +856,7 @@ public abstract class MojoBase extends AbstractMojo {
             pom.append("<repositories>\n");
             pom.append("<repository>\n");
             pom.append("    <id>papermc</id>\n");
-            pom.append("    <url>https://papermc.io/repo/repository/maven-public/</url>\n");
+            pom.append("    <url>https://repo.papermc.io/repository/maven-public/</url>\n");
             pom.append("</repository>\n");
             pom.append("<repository>\n");
             pom.append("    <id>minecraft-libraries</id>\n");


### PR DESCRIPTION
As announced in the [Paper discord](https://canary.discord.com/channels/289587909051416579/492517675680006144/977178679706779659), the old `/api` and `/repo` endpoints have been changed to subdomains. Even though the old paths will keep working for the foreseeable future, changing them now won't hurt.