### PR TITLE
Close the output JAR file

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -785,6 +785,9 @@ public abstract class MojoBase extends AbstractMojo {
         // Finish up tiny-remapper
         remapper.finish();
 
+        // Close the input jar
+        inputJar.close();
+
         // Close the output jar
         outputFileSystem.close();
     }


### PR DESCRIPTION
On Windows, the paper JAR could not be deleted because the file was still opened. This caused the entire build to fail. This closes the JAR file, allowing the file to be deleted.