### PR TITLE
Remap artifact/classes twice instead of once

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Although you probably want to use Gradle and [paperweight-userdev](https://githu
         <plugin>
             <groupId>ca.bkaw</groupId>
             <artifactId>paper-nms-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>1.3</version>
             <executions>
                 <execution>
                     <phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.bkaw</groupId>
     <artifactId>paper-nms-maven-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.3</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -283,7 +283,7 @@ public abstract class MojoBase extends AbstractMojo {
             Path spigotMemberMappingsPath = cacheDirectory.resolve("spigot_member_mappings_"+ gameVersion +".csrg");
             this.downloadSpigotMappings(spigotClassMappingsPath, spigotMemberMappingsPath, gameVersion);
 
-            getLog().info("Merge mappings");
+            getLog().info("Merging mappings");
             this.mergeMappings(spigotClassMappingsPath, spigotMemberMappingsPath, mojangMappingsPath, mappingsPath, mappingsMojangPath, mappingsSpigotPath);
 
             Path paperclipPath = cacheDirectory.resolve("paperclip.jar");

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -272,6 +272,9 @@ public abstract class MojoBase extends AbstractMojo {
             // No dev-bundle exists for this version, let's create
             // mappings and map the jar manually.
 
+            Path mappingsMojangPath = cacheDirectory.resolve("mappings_" + gameVersion + "_mojang.tiny");
+            Path mappingsSpigotPath = cacheDirectory.resolve("mappings_" + gameVersion + "_spigot.tiny");
+
             Path mojangMappingsPath = cacheDirectory.resolve("mojang_mappings.txt");
             this.downloadMojangMappings(mojangMappingsPath, gameVersion);
 
@@ -280,8 +283,8 @@ public abstract class MojoBase extends AbstractMojo {
             Path spigotMemberMappingsPath = cacheDirectory.resolve("spigot_member_mappings_"+ gameVersion +".csrg");
             this.downloadSpigotMappings(spigotClassMappingsPath, spigotMemberMappingsPath, gameVersion);
 
-            getLog().info("Merging mappings");
-            this.mergeMappings(spigotClassMappingsPath, spigotMemberMappingsPath, mojangMappingsPath, mappingsPath);
+            getLog().info("Merge mappings");
+            this.mergeMappings(spigotClassMappingsPath, spigotMemberMappingsPath, mojangMappingsPath, mappingsPath, mappingsMojangPath, mappingsSpigotPath);
 
             Path paperclipPath = cacheDirectory.resolve("paperclip.jar");
             this.downloadPaper(gameVersion, paperclipPath);
@@ -485,15 +488,17 @@ public abstract class MojoBase extends AbstractMojo {
     /**
      * Merge the spigot mappings and the Mojang mappings to create mappings from
      * Spigot mappings to Mojang mappings, and write the mappings to a file in the
-     * tiny format.
+     * tiny format. Also write the original Spigot and Mojang mappings to files.
      *
      * @param spigotClassMappingsPath The path of the Spigot class mappings (csrg).
      * @param spigotMemberMappingsPath The path of the Spigot member mappings (csrg).
      * @param mojangMappingsPath The path of the mojang mappings (proguard).
      * @param outputPath The path to put the merged mappings (tiny).
+     * @param outputMojangPath The path to put the mojang mappings (tiny).
+     * @param outputSpigotPath The path to put the spigot mappings (tiny).
      * @throws MojoExecutionException If something goes wrong.
      */
-    public void mergeMappings(Path spigotClassMappingsPath, Path spigotMemberMappingsPath, Path mojangMappingsPath, Path outputPath) throws MojoExecutionException {
+    public void mergeMappings(Path spigotClassMappingsPath, Path spigotMemberMappingsPath, Path mojangMappingsPath, Path outputPath, Path outputMojangPath, Path outputSpigotPath) throws MojoExecutionException {
         MappingSet spigotMappings;
         MappingSet mojangMappings;
 
@@ -527,6 +532,8 @@ public abstract class MojoBase extends AbstractMojo {
 
         try {
             TinyMappingFormat.TINY_2.write(mappings, outputPath, "spigot", "mojang");
+            TinyMappingFormat.TINY_2.write(mojangMappings, outputMojangPath, "mojang", "obfuscated");
+            TinyMappingFormat.TINY_2.write(spigotMappings, outputSpigotPath, "obfuscated", "spigot");
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to write merged mappings", e);
         }
@@ -819,6 +826,7 @@ public abstract class MojoBase extends AbstractMojo {
         getLog().info("Cleaning up paper jar");
         try {
             Files.delete(paperPath);
+            Files.delete(mappingsPath);
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to delete paper jar", e);
         }


### PR DESCRIPTION
Currently to remap the code from Mojang mappings to Spigot mappings, the two mappings are merged together and then applied as one mapping. I unfortunately ran into an improperly mapped method on 1.17 due to this strategy. The situation is as follows. The class `PlayerConnection` extends `ServerPlayerConnection`. Spigot's mappings define a mapping for a method called `sendPacket` from `a` on `ServerPlayerConnection`, but not on `PlayerConnection`. Mojang's mappings define a mapping from `send` to `a` on `ServerPlayerConnection` as well as `PlayerConnection`. Merging these two leaves us with the following mapping:
```
mojang	spigot
net/minecraft/server/network/ServerGamePacketListenerImpl	net/minecraft/server/network/PlayerConnection
	send	a
net/minecraft/server/network/ServerPlayerConnection	net/minecraft/server/network/ServerPlayerConnection
	send	sendPacket
```
Since Lorenz does not have context for the mappings, it does not know that these two classes are related. Therefore, we now have two mappings for the same method, which are actually named differently. When using this with tiny-remapper, it ends up using the `a` name. The server jar however, uses the `sendPacket` name, meaning that you end up with a `NoSuchMethodError` when calling this method after remapping.

This pull request addresses this by not merging the mappings, but instead mapping the classes twice. The issue here, as mentioned earlier, is that Lorenz cannot know that these classes are related. However, tiny-remapper does know this. By mapping the jar twice, this means that it can properly use this context in the second step. When it maps from Mojang to obfuscated, it properly maps `send` to `a`. When mapping from Spigot it will now also map `a` to `sendPacket`, because it knows that the parent class of this method has this name and propagates it to its children. This means that this two-step process properly maps from `send` to `sendPacket`.

The initialization phase remains largely the same with the change that the merged mappings are no longer stored. Instead the Spigot and Mojang mappings are stored to be used in the remapping phase. Users that currently have full mappings stored need to re-initialize 1.17 again if this pull request is accepted. The remapping phase now first maps the final artifact/classes from Mojang names to obfuscated names as specified by the Mojang mappings. It then does this for all of the dependencies as well. We need to do this, since the dependencies are needed as the classpath for the second remapping step. Once all dependencies have been mapped to obfuscated names, the initial artifact/classes are mapped from obfuscated names to Spigot names as specified by the Spigot mappings. This is the final result of this plugin and the resulting artifact/classes can be further used by Maven. The temporarily remapped dependencies are deleted, as well as other temporary files. This process only happens when no dev-bundle is present; versions which have a dev-bundle behave the same as before.

This change resolves the issue mentioned earlier. I've compared the final output of this plugin with and without these changes for my code and, with the exception of `send` now being mapped properly, the other names remain identical. I cannot say with complete certainty that this is the case for all names, but testing seems to indicate that this is the case.