### PR TITLE
Fix issues on initialisation in remap phase

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -35,10 +35,7 @@ public class RemapMojo extends MojoBase {
         Path mappingsMojangPath = cacheDirectory.resolve("mappings_" + gameVersion + "_mojang.tiny");
         Path mappingsSpigotPath = cacheDirectory.resolve("mappings_" + gameVersion + "_spigot.tiny");
 
-        boolean hasMojangMappings = Files.exists(mappingsMojangPath);
-        boolean hasSpigotMappings = Files.exists(mappingsSpigotPath);
-
-        if (hasMojangMappings != hasSpigotMappings) {
+        if (Files.exists(mappingsMojangPath) != Files.exists(mappingsSpigotPath)) {
             // One of the files is missing, delete the mappings and initialize again
             getLog().info("Broken mappings found, running init");
 
@@ -74,10 +71,12 @@ public class RemapMojo extends MojoBase {
             classPath.add(artifact.getFile().toPath());
         }
 
-        if (!Files.exists(mappingsPath) && !hasMojangMappings) {
+        if (!Files.exists(mappingsPath) && !Files.exists(mappingsMojangPath)) {
             getLog().info("No mappings found, running init");
             this.init();
         }
+
+        boolean hasMojangMappings = Files.exists(mappingsMojangPath);
 
         if (!hasMojangMappings) {
             try {
@@ -129,7 +128,7 @@ public class RemapMojo extends MojoBase {
             }
         });
 
-        if (hasMojangMappings && hasSpigotMappings) {
+        if (hasMojangMappings) {
             remapDouble(inputPath, mappingsMojangPath, mappingsSpigotPath, classPath);
         } else {
             if (Files.isDirectory(inputPath)) {

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -40,9 +40,9 @@ public class RemapMojo extends MojoBase {
             getLog().info("Broken mappings found, running init");
 
             try {
-                Files.delete(mappingsPath);
-                Files.delete(mappingsMojangPath);
-                Files.delete(mappingsSpigotPath);
+                Files.deleteIfExists(mappingsPath);
+                Files.deleteIfExists(mappingsMojangPath);
+                Files.deleteIfExists(mappingsSpigotPath);
             } catch (IOException exception) {
                 throw new MojoExecutionException("Unable to delete mappings", exception);
             }


### PR DESCRIPTION
There are currently two issues with initialisation during the remapping phase, which happens if classes/artifacts are attempted to be remapped, but the mappings are not found/invalid (both of which are my fault, sorry).

The first issue is that after running the initialisation phase, the internal state as to whether the mappings exist was not updated, meaning that the remap would continue as if the mappings didn't exist, causing a failure.

The second issue is that if there are broken mappings (i.e., either Mojang or Spigot mappings exist, but not both), it would try to delete all mappings and re-initialise to fix this. However, since not all mapping files exist, it would try to delete non-existent files, causing a failure.

This PR addresses both of these issues.