### PR TITLE
Add MixinExtension

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -3,6 +3,7 @@ package ca.bkaw.papernmsmavenplugin;
 import net.fabricmc.tinyremapper.IMappingProvider;
 import net.fabricmc.tinyremapper.TinyRemapper;
 import net.fabricmc.tinyremapper.TinyUtils;
+import net.fabricmc.tinyremapper.extension.mixin.MixinExtension;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
@@ -155,6 +156,7 @@ public class RemapMojo extends MojoBase {
         TinyRemapper remapper = TinyRemapper.newRemapper()
             .withMappings(mappings)
             .ignoreConflicts(true)
+            .extension(new MixinExtension())
             .build();
 
         // Add the class path


### PR DESCRIPTION
Sorry if this is hard to read as I am using DeepL translation.

This pull request will generate a Mojang mapping (.srg) and extend the scope of the remapping to Mixin annotations. If it is only an extension, just add `.extension(new MixinExtension())` to TinyRemapper. However, in order for the remapping to be applied, Mixin must be compiled with the remap flag enabled, and the mapping file (.srg) must be loaded into Mixin. Since the dev-bundle contains only what needs to be remapped, it is not appropriate to load it into Mixin due to the lack of methods and fields. For this reason, we generate Mojang mappings even when using the dev-bundle.

**Example of remapping:**
```
@Inject(at = {@At("RETURN")}, method = {"tick()V"})
@Inject(at = {@At("RETURN")}, method = {"k()V"})
```

**Example of pom.xml:**
https://github.com/tonbei/PaperShelledPluginMavenTemplate/blob/master/pom.xml