### PR TITLE
Add MixinExtension

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -3,6 +3,7 @@ package ca.bkaw.papernmsmavenplugin;
 import net.fabricmc.tinyremapper.IMappingProvider;
 import net.fabricmc.tinyremapper.TinyRemapper;
 import net.fabricmc.tinyremapper.TinyUtils;
+import net.fabricmc.tinyremapper.extension.mixin.MixinExtension;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
@@ -178,6 +179,7 @@ public class RemapMojo extends MojoBase {
         TinyRemapper remapper = TinyRemapper.newRemapper()
             .withMappings(mappings)
             .ignoreConflicts(true)
+            .extension(new MixinExtension())
             .build();
 
         // Add the class path


### PR DESCRIPTION
Added MixinExtension to remap references in mixin too
When used with `process-classes` phase, MixinExtension logs unharmful warns but works fine when phase is `package` is used (Currently i dont have idea how to fix this)