### PR TITLE
Fix double remapping only applying one mapping

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -138,7 +138,7 @@ public class RemapMojo extends MojoBase {
             if (Files.isDirectory(inputPath)) {
                 // A directory, we are before the package stage, we need to remap the classes
                 getLog().info("Remapping classes");
-                this.remapClasses(inputPath, mappingsPath, mappingFrom, mappingTo, classPath);
+                this.remapClassesCached(inputPath, mappingsPath, mappingFrom, mappingTo, classPath);
             } else {
                 // A file, we are at the package stage, we need to remap the jar
                 Path outputPath = cacheDirectory.resolve("remapped.jar");
@@ -161,7 +161,7 @@ public class RemapMojo extends MojoBase {
         }
     }
 
-    public void remapClasses(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath) throws MojoExecutionException {
+    public void remapClassesCached(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath) throws MojoExecutionException {
         // Read information about which classes have already been remapped
         if (this.remappedClasses == null) {
             try {
@@ -194,6 +194,35 @@ public class RemapMojo extends MojoBase {
                     Files.write(path, bytes);
                     this.remappedClasses.markAsRemappedNow(path);
                 }
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to write class " + name, e);
+            }
+        });
+
+        // Finish up tiny-remapper
+        remapper.finish();
+    }
+
+    public void remapClasses(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath) {
+        // Read the mappings
+        IMappingProvider mappings = TinyUtils.createTinyMappingProvider(mappingsPath, mappingFrom, mappingTo);
+
+        // Create the remapper
+        TinyRemapper remapper = TinyRemapper.newRemapper()
+                .withMappings(mappings)
+                .ignoreConflicts(true)
+                .build();
+
+        // Add the class path
+        remapper.readClassPath(classPath.toArray(new Path[0]));
+
+        // Add input classes
+        remapper.readInputs(classesPath);
+
+        // Run the remapper and write classes
+        remapper.apply((name, bytes) -> {
+            try {
+                Files.write(classesPath.resolve(name + ".class"), bytes);
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to write class " + name, e);
             }

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -138,7 +138,7 @@ public class RemapMojo extends MojoBase {
             if (Files.isDirectory(inputPath)) {
                 // A directory, we are before the package stage, we need to remap the classes
                 getLog().info("Remapping classes");
-                this.remapClassesCached(inputPath, mappingsPath, mappingFrom, mappingTo, classPath);
+                this.remapClasses(inputPath, mappingsPath, mappingFrom, mappingTo, classPath, true);
             } else {
                 // A file, we are at the package stage, we need to remap the jar
                 Path outputPath = cacheDirectory.resolve("remapped.jar");
@@ -161,7 +161,7 @@ public class RemapMojo extends MojoBase {
         }
     }
 
-    public void remapClassesCached(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath) throws MojoExecutionException {
+    public void remapClasses(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath, boolean markRemapping) throws MojoExecutionException {
         // Read information about which classes have already been remapped
         if (this.remappedClasses == null) {
             try {
@@ -192,37 +192,11 @@ public class RemapMojo extends MojoBase {
                 Path path = classesPath.resolve(name + ".class");
                 if (!this.remappedClasses.isAlreadyRemapped(path)) {
                     Files.write(path, bytes);
-                    this.remappedClasses.markAsRemappedNow(path);
+
+                    if (markRemapping) {
+                        this.remappedClasses.markAsRemappedNow(path);
+                    }
                 }
-            } catch (IOException e) {
-                throw new UncheckedIOException("Failed to write class " + name, e);
-            }
-        });
-
-        // Finish up tiny-remapper
-        remapper.finish();
-    }
-
-    public void remapClasses(Path classesPath, Path mappingsPath, String mappingFrom, String mappingTo, List<Path> classPath) {
-        // Read the mappings
-        IMappingProvider mappings = TinyUtils.createTinyMappingProvider(mappingsPath, mappingFrom, mappingTo);
-
-        // Create the remapper
-        TinyRemapper remapper = TinyRemapper.newRemapper()
-                .withMappings(mappings)
-                .ignoreConflicts(true)
-                .build();
-
-        // Add the class path
-        remapper.readClassPath(classPath.toArray(new Path[0]));
-
-        // Add input classes
-        remapper.readInputs(classesPath);
-
-        // Run the remapper and write classes
-        remapper.apply((name, bytes) -> {
-            try {
-                Files.write(classesPath.resolve(name + ".class"), bytes);
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to write class " + name, e);
             }
@@ -258,7 +232,7 @@ public class RemapMojo extends MojoBase {
         // Map from Mojang to obfuscated
         if (Files.isDirectory(artifactPath)) {
             getLog().info("Remapping classes to obfuscated form");
-            this.remapClasses(artifactPath, mappingsMojangPath, "mojang", "obfuscated", classPath);
+            this.remapClasses(artifactPath, mappingsMojangPath, "mojang", "obfuscated", classPath, false);
         } else {
             Path outputPath = getCacheDirectory().resolve("remapped.jar");
             getLog().info("Remapping artifact to obfuscated form");
@@ -294,7 +268,7 @@ public class RemapMojo extends MojoBase {
         // Map from obfuscated to Spigot
         if (Files.isDirectory(artifactPath)) {
             getLog().info("Remapping classes to Spigot mappings");
-            this.remapClasses(artifactPath, mappingsSpigotPath, "obfuscated", "spigot", newClassPath);
+            this.remapClasses(artifactPath, mappingsSpigotPath, "obfuscated", "spigot", newClassPath, true);
         } else {
             Path outputPath = getCacheDirectory().resolve("remapped_2.jar");
             getLog().info("Remapping artifact to Spigot mappings");


### PR DESCRIPTION
When a dev bundle is absent (in particular on versions prior to 1.17.1), the output is mapped twice: once from Mojang mappings to obfuscated mappings and then again from obfuscated mappings to Spigot mappings. I ran into an issue where only the first mapping is applied, but the second is not, resulting in classes not being found at runtime due to their improper names.

This issue occurs because of the caching of classes via the `classes.json` file. It keeps track of the time at which classes were last modified. If a class has not changed, the class is not remapped, since it is presumed to already be remapped. This stratey works well when a single mapping step is applied. However, when the classes need to be mapped twice, this results in only one mapping being applied, since the class is marked as properly remapped and therefore won't be remapped again. I have tested against older version 1.3.2, which did not have a classes cache, and that version does not have this issue. This pull request also resolves this problem. 

I've renamed the current `remapClasses` method to `remapClassesCached` and introduced a new `remapClasses` method. The former method behaves the same, but the new method ignores the `classes.json` file. In case a dev bundle is present, the `remapClassesCached` method is used, but when two mappings are applied the new `remapClasses` method is used. This way the classes cache is still used when possible, but doesn't get in the way of the double remapping.

Let me know if you want me to change anything about this PR.