### PR TITLE
Use one cache directory per game version to allow parallel runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.bkaw</groupId>
     <artifactId>paper-nms-maven-plugin</artifactId>
-    <version>1.4.8</version>
+    <version>1.4.9-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -273,7 +273,7 @@ public abstract class MojoBase extends AbstractMojo {
         this.createDevBundleConfiguration();
 
         String gameVersion = this.getGameVersion();
-        Path cacheDirectory = this.getCacheDirectory();
+        Path cacheDirectory = this.getCacheDirectory().resolve(gameVersion);
 
         String extra = !"paper-nms".equals(this.devBundle.id) ? " (" + this.devBundle.id + ")" : "";
         getLog().info("Initializing paper-nms for game version: " + gameVersion + extra);

--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -34,7 +34,7 @@ public class RemapMojo extends MojoBase {
         Path inputPath = this.project.getArtifact().getFile().toPath();
 
         String gameVersion = this.getGameVersion();
-        Path cacheDirectory = this.getCacheDirectory();
+        Path cacheDirectory = this.getCacheDirectory().resolve(gameVersion);
         Path mappingsPath = cacheDirectory.resolve("mappings_" + gameVersion + ".tiny");
         Path missingMappingsPath = Paths.get(mappingsPath + ".missing");
 


### PR DESCRIPTION
This creates one cache directly per version in the `.paper-nms` directory to allow multiple modules using the plugin to run in parallel. Especially the `init` part will fail if multiple threads try to access the same files (e.g. download `paperclip.jar` or delete paperclip-generated files).

Moving each version into one separate folder cleanly solves that and allows for multi-modules support with multiple versions to build quickly in parallel.