### PR TITLE
Ensure cache directory uses the project's parent path only when it exists.

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/MojoBase.java
@@ -97,7 +97,7 @@ public abstract class MojoBase extends AbstractMojo {
      * @return The path to the cache directory.
      */
     public Path getCacheDirectory() {
-        MavenProject project = this.project.hasParent() ? this.project.getParent() : this.project;
+        MavenProject project = this.project.hasParent() && this.project.getParent().getBasedir() != null ? this.project.getParent() : this.project;
 
         return project.getBasedir().toPath().resolve(".paper-nms");
     }


### PR DESCRIPTION
In our somewhat unusual setup, the parent project exists without a base directory. This small change adds a simple safeguard for that case.

It shouldn’t affect typical configurations, but may help others who run into a similar situation down the line.