### PR TITLE
Mark remapping as threadsafe to allow running parallel

### DIFF
--- a/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
+++ b/src/main/java/ca/bkaw/papernmsmavenplugin/RemapMojo.java
@@ -23,7 +23,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-@Mojo(name = "remap", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "remap", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class RemapMojo extends MojoBase {
     private RemappedClasses remappedClasses;
 


### PR DESCRIPTION
This marks the RemapMojo as threadsafe. Support for parallel running of the remapping was added in 68716841b3726c69a12b9d30d3cb3a3f4c10fdea already, but Maven needs to have that explicitly specified now